### PR TITLE
Clean and analyze remaining ballot ready files

### DIFF
--- a/10_code/10_prepare_data/50_clean_BallotReady_early.py
+++ b/10_code/10_prepare_data/50_clean_BallotReady_early.py
@@ -1,0 +1,59 @@
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import glob
+from matplotlib import pyplot as plt
+
+# Load Ballot Ready Early Voting 2020
+data = pd.read_excel('../../00_source_data/Early_Voting_Data/BallotReady_2018_2020_Early Voting Data.xlsx',sheet_name='2020 In-Person Early Voting')
+
+# Load Ballot Ready Early Voting 2018
+data18 = pd.read_excel('../../00_source_data/Early_Voting_Data/BallotReady_2018_2020_Early Voting Data.xlsx',sheet_name='2018 In Person Early Voting')
+
+#Dropoff
+drop20 = pd.read_excel('../../00_source_data/Early_Voting_Data/BallotReady_2018_2020_Early Voting Data.xlsx',sheet_name='2020 Dropoff Locations')
+drop18 = pd.read_excel('../../00_source_data/Early_Voting_Data/BallotReady_2018_2020_Early Voting Data.xlsx',sheet_name='2018 Dropoff Locations')
+
+###
+# Creat Geodataframe
+###
+
+from shapely import wkt
+data['st_astext'] = data['st_astext'].apply(wkt.loads)
+data = gpd.GeoDataFrame(data,geometry='st_astext')
+
+#Drop NA geometries in 2018
+data18 = data18[data18['st_astext'].notna()]
+data18['st_astext'] = data18['st_astext'].apply(wkt.loads)
+data18 = gpd.GeoDataFrame(data18,geometry='st_astext')
+
+drop20['st_astext'] = drop20['st_astext'].apply(wkt.loads)
+drop20 = gpd.GeoDataFrame(drop20,geometry='st_astext')
+
+#Drop NA geometries in 2018
+drop18 = drop18[drop18['st_astext'].notna()]
+drop18['st_astext'] = drop18['st_astext'].apply(wkt.loads)
+drop18 = gpd.GeoDataFrame(drop18,geometry='st_astext')
+
+#Project and Save 
+data_geo = data.set_crs(epsg=4326)
+data18_geo = data18.set_crs(epsg=4326)
+drop18_geo = drop18.set_crs(epsg=4326)
+drop20_geo = drop20.set_crs(epsg=4326)
+
+data_geo.to_file(
+    "../../20_intermediate_files/10_polling_places/2020_BallotReady_Early.geojson",
+    driver="GeoJSON",
+)
+data18_geo.to_file(
+    "../../20_intermediate_files/10_polling_places/2018_BallotReady_Early.geojson",
+    driver="GeoJSON",
+)
+drop18_geo.to_file(
+    "../../20_intermediate_files/10_polling_places/2018_BallotReady_Dropoff_Early.geojson",
+    driver="GeoJSON",
+)
+drop20_geo.to_file(
+    "../../20_intermediate_files/10_polling_places/2020_BallotReady_Dropoff_Early.geojson",
+    driver="GeoJSON",
+)

--- a/10_code/data_explortations/BallotReadyReview.ipynb
+++ b/10_code/data_explortations/BallotReadyReview.ipynb
@@ -1,0 +1,532 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/jasmineyoung/opt/anaconda3/lib/python3.8/site-packages/geopandas/_compat.py:111: UserWarning: The Shapely GEOS version (3.8.0-CAPI-1.13.1 ) is incompatible with the GEOS version PyGEOS was compiled with (3.9.1-CAPI-1.14.2). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import geopandas as gpd\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/jasmineyoung/Documents/MIDS/mtv_viacom_capstone/10_code/data_explortations\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pwd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "early20 = gpd.read_file('../../20_intermediate_files/10_polling_places/2020_BallotReady_Early.geojson')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "early18 = gpd.read_file('../../20_intermediate_files/10_polling_places/2018_BallotReady_Early.geojson')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "drop20 = gpd.read_file('../../20_intermediate_files/10_polling_places/2020_BallotReady_Dropoff_Early.geojson')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "drop18 = gpd.read_file('../../20_intermediate_files/10_polling_places/2018_BallotReady_Dropoff_Early.geojson')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2020 Early Voting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "45"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early20['state'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9852"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9852"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early20['polling_place_id'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9544"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early20['address_line_1'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9599"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early20['formatted_address'].unique())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2018 Early Voting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "37"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early18['state'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8187"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early18)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8187"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early18['polling_place_id'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7376"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early18['address_line_1'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7161"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(early18['formatted_address'].unique())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2020 Dropoff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "48"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop20['state'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12619"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12619"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop20['polling_place_id'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "11215"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop20['address_line_1'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "11187"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop20['formatted_address'].unique())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2018 Dropoff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop18['state'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1383"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop18)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1383"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop18['polling_place_id'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1169"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop18['address_line_1'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1008"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(drop18['formatted_address'].unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Hi All,

I updated the Ballot Ready cleaning file so that it cleans 2020 EV, 2018 EV, 2020 Dropoff, and 2018 Dropoff. Additionally, I did some analysis on Ballot Ready's data coverage and summarized them below. 

For 2020 Early Voting:
- Covers 45 States
- 9,852 Polling Places
- Potentially 250-300 duplicates based on address

For 2018 Early Voting:
- Covers 37 States
- 8,187 Polling Places
- Potentially 800-1,000 duplicates based on address

For 2020 Dropoff:
- Covers 48 States
- 12,619 Polling Places
- Potentially 1,400-1,500 duplicates based on address

For 2018 Dropoff:
- Covers 5 states
- 1,383 Polling Places
- Potentially 200-300 duplicates based on address

Looking forward to discussing tomorrow!